### PR TITLE
Fix details.js include for onTwigSiteVariables().

### DIFF
--- a/markdown-details.php
+++ b/markdown-details.php
@@ -114,7 +114,8 @@ class MarkdownDetailsPlugin extends Plugin
             $this->grav['assets']
                 ->add('plugin://markdown-details/assets/details.css');
         }
-        if ( $this->a11y )
+
+        if ($this->config->get('plugins.markdown-details.a11y');)
         {
             $this->grav['assets']->add('plugin://markdown-details/js/details.js', ['group' => 'bottom']);
         }


### PR DESCRIPTION
I had issues with the collapsible portions working out of the box.  It seems that details.js was not getting included with the `a11y` variable set to true.

It seems that the plugin object's variables aren't initialized for the `onTwigSiteVariables()` method.  This just does what the `built_in_css` setting does and calls it directly.